### PR TITLE
TRITON-2428 sdcnode v20.x for minimal-64-lts@23.4.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2022 Joyent, Inc.
+ * Copyright 2024 MNX Cloud, Inc.
  */
 
 @Library('jenkins-joylib@v1.0.8') _
@@ -85,6 +86,18 @@ pipeline {
                     steps {
                         sh('''
 ./tools/build_jenkins -u a7199134-7e94-11ec-be67-db6f482136c2 -p $MIN_PLATFORM_STAMP_NG
+        ''')
+                    }
+                }
+                stage('minimal-64-lts 23.4.0') {
+                    agent {
+                        node {
+                            label joyCommonLabels(image_ver: '23.4.0', pi: '20210826T002459Z')
+                        }
+                    }
+                    steps {
+                        sh('''
+./tools/build_jenkins -u 5e4c3f98-aca4-11ee-9db8-00151714048c -p $MIN_PLATFORM_STAMP_NG
         ''')
                     }
                 }

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 #
 # Copyright 2022 Joyent, Inc.
-# Copyright 2023 MNX Cloud, Inc.
+# Copyright 2024 MNX Cloud, Inc.
 #
 
 #
@@ -27,6 +27,10 @@ include ./deps/eng/tools/mk/Makefile.defs
 # probably be in the previously included Makefile.defs anyway.
 ifeq ($(shell $(_AWK) '/^Image/ {print $$3}' < /etc/product),21.4.0)
 BASE_IMAGE_UUID = a7199134-7e94-11ec-be67-db6f482136c2
+BUILD_PLATFORM  = 20210826T002459Z
+endif
+ifeq ($(shell $(_AWK) '/^Image/ {print $$3}' < /etc/product),23.4.0)
+BASE_IMAGE_UUID = 5e4c3f98-aca4-11ee-9db8-00151714048c
 BUILD_PLATFORM  = 20210826T002459Z
 endif
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-This repository is part of the Joyent Triton project. See the [contribution
-guidelines](https://github.com/joyent/triton/blob/master/CONTRIBUTING.md)
+This repository is part of the Triton Data Center project. See the [contribution
+guidelines](https://github.com/TritonDataCenter/triton/blob/master/CONTRIBUTING.md)
 and general documentation at the main
-[Triton project](https://github.com/joyent/triton) page.
+[Triton project](https://github.com/TritonDataCenter/triton) page.
 
 # sdcnode
 
@@ -22,10 +22,10 @@ To build the sdcnodes for the matching image as the building machine:
 
 ## CI
 
-Typically sdcnode builds for all targetted images are built for each commit
-via Joyent Engineering's internal Jenkins CI system. See
-<https://jenkins.joyent.us/view/sdcnode/> (internal access). They are published
-to <https://download.joyent.com/pub/build/sdcnode/> (public).
+Typically sdcnode builds for all targetted images are built for each commit via
+the Triton Data Center Jenkins instance. See
+<https://jenkins.tritondatacenter.com/job/TritonDataCenter/job/sdcnode/>. They
+are published to <https://download.tritondatacenter.com/pub/build/sdcnode/>.
 
 ## Build configurations
 
@@ -34,7 +34,7 @@ are built. There are configurations for a matrix of the following variables:
 
 - node.js version
 
-- origin image, e.g. [minimal-multiarch](https://docs.joyent.com/public-cloud/instances/infrastructure/images/smartos/minimal), which implies a pkgsrc generation and sometimes the `gcc` version used
+- origin image, e.g. [minimal-64-lts](https://docs.tritondatacenter.com/public-cloud/instances/infrastructure/images/smartos/minimal), which implies a pkgsrc generation and sometimes the `gcc` version used
 
 - "build tag" for different build/configuration paramters:
 
@@ -66,7 +66,7 @@ Here are some commands to see a breakdown of current sdcnode configs:
 Here is a *start* at commands to list current usage of sdcnode configs by
 Triton and Manta components.
 
-1. Setup `jr` per <https://github.com/joyent/joyent-repos#jr>.
+1. Setup `jr` per <https://github.com/TritonDataCenter/joyent-repos#jr>.
 
 2. Get and update a clone of all top-level Triton/Manta release repos:
 

--- a/nodeconfigs.json
+++ b/nodeconfigs.json
@@ -1,5 +1,34 @@
 [
     {
+        "// image": "minimal-64-lts 23.4.0",
+        "image": "5e4c3f98-aca4-11ee-9db8-00151714048c",
+        "version": "v20.11.0",
+        "patch_files": [
+            "patches/http-keepAliveTimeout-default-0-v20.x.patch",
+            "patches/no-madvise-prototype.patch"
+        ],
+        "configure_flags": "--dest-cpu=x64",
+        "gcc": "/opt/local/gcc13/bin/gcc",
+        "cflags": "-fno-aggressive-loop-optimizations",
+        "rpath": "$ORIGIN/../lib",
+        "include_gcc_runtime_libs": true,
+        "build_tag": "gz"
+    },
+    {
+        "// image": "minimal-64-lts 23.4.0",
+        "image": "5e4c3f98-aca4-11ee-9db8-00151714048c",
+        "comment": "For use by services running in zones. Statically link to OpenSSL and zlib *for now* until OS-1294/TOOLS-130.",
+        "version": "v20.11.0",
+        "patch_files": [
+            "patches/http-keepAliveTimeout-default-0-v20.x.patch",
+            "patches/no-madvise-prototype.patch"
+        ],
+        "configure_flags": "--dest-cpu=x64",
+        "gcc": "/opt/local/gcc13/bin/gcc",
+        "cflags": "-fno-aggressive-loop-optimizations",
+        "build_tag": "zone64"
+    },
+    {
         "// image": "minimal-64-lts 21.4.0",
         "image": "a7199134-7e94-11ec-be67-db6f482136c2",
         "version": "v8.17.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdcnode",
   "description": "builds of node for SDC",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "author": "MNX Cloud, Inc.",
   "engines": [

--- a/patches/http-keepAliveTimeout-default-0-v20.x.patch
+++ b/patches/http-keepAliveTimeout-default-0-v20.x.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/_http_server.js b/lib/_http_server.js
+index 775090b373..87eaa53f7e 100644
+--- a/lib/_http_server.js
++++ b/lib/_http_server.js
+@@ -475,7 +475,7 @@ function storeHTTPOptions(options) {
+     validateInteger(keepAliveTimeout, 'keepAliveTimeout', 0);
+     this.keepAliveTimeout = keepAliveTimeout;
+   } else {
+-    this.keepAliveTimeout = 5_000; // 5 seconds;
++    this.keepAliveTimeout = 0; // 0 seconds;
+   }
+ 
+   const connectionsCheckingInterval = options.connectionsCheckingInterval;

--- a/patches/no-madvise-prototype.patch
+++ b/patches/no-madvise-prototype.patch
@@ -1,0 +1,21 @@
+Remove madvise prototype to avoid conflicting types.
+
+diff --git a/deps/v8/src/base/platform/platform-posix.cc b/deps/v8/src/base/platform/platform-posix.cc
+index 664ed301c8..cb2bf6958a 100644
+--- a/deps/v8/src/base/platform/platform-posix.cc
++++ b/deps/v8/src/base/platform/platform-posix.cc
+@@ -72,14 +72,6 @@
+ #define MAP_ANONYMOUS MAP_ANON
+ #endif
+ 
+-#if defined(V8_OS_SOLARIS)
+-#if (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE > 2) || defined(__EXTENSIONS__)
+-extern "C" int madvise(caddr_t, size_t, int);
+-#else
+-extern int madvise(caddr_t, size_t, int);
+-#endif
+-#endif
+-
+ #ifndef MADV_FREE
+ #define MADV_FREE MADV_DONTNEED
+ #endif

--- a/tools/build-a-node
+++ b/tools/build-a-node
@@ -7,6 +7,7 @@
 
 #
 # Copyright 2021 Joyent, Inc.
+# Copyright 2024 MNX Cloud, Inc.
 #
 
 #
@@ -193,7 +194,7 @@ make V=1 CC=$GCC CXX=$GXX \
 # node build needs to (a) include the needed GCC runtime libs and (b) set a
 # RUNPATH for the node binary to find them.
 #
-# See <https://github.com/joyent/rfd/tree/master/rfd/0059#problems-with-the-gz>
+# See <https://github.com/TritonDataCenter/rfd/tree/master/rfd/0059#problems-with-the-gz>
 # for details.
 includeGccRuntimeLibs=$(echo "$buildOpts" | json include_gcc_runtime_libs)
 if [[ -n "$includeGccRuntimeLibs" ]]; then

--- a/tools/build-a-node
+++ b/tools/build-a-node
@@ -184,7 +184,8 @@ if [[ -n ${MAKE_JOBS} ]]; then
 fi
 make ${JOBS_ARG} V=1 CC=$GCC CXX=$GXX \
      CFLAGS="${cflags}" CXXFLAGS="${cflags}"
-make V=1 CC=$GCC CXX=$GXX install
+make V=1 CC=$GCC CXX=$GXX \
+     CFLAGS="${cflags}" CXXFLAGS="${cflags}" install
 
 # Optionally include GCC runtime libs. If a version of GCC was used to compile
 # node is greater than the version of the GCC runtime libs included in the

--- a/tools/build-a-node
+++ b/tools/build-a-node
@@ -199,6 +199,7 @@ includeGccRuntimeLibs=$(echo "$buildOpts" | json include_gcc_runtime_libs)
 if [[ -n "$includeGccRuntimeLibs" ]]; then
     ldd ./node  | awk '{print $3}' | grep '^/opt/local/gcc' | while read lib; do
         cp $lib $buildDir/node/lib/
+        $ELFEDIT -e 'dyn:runpath $ORIGIN' $buildDir/node/lib/$(basename $lib)
     done
 fi
 


### PR DESCRIPTION
This is currently blocked on TRITON-2426 and https://github.com/TritonDataCenter/triton-origin-image/pull/10 but once that's complete and we have a 23.4.0 Jenkins agent I can push a test build for this and get it integrated.  For now tested locally in a 23.4.0 zone.